### PR TITLE
1 workflow for prebuilt images

### DIFF
--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -18,7 +18,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Dev Container - NX
-        uses: devcontainers/cli@v0.3
+        uses: devcontainers/ci@v0.3
         with:
           subFolder: common/nx
           configFile: common/nx/devcontainer.json

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,4 +25,3 @@ jobs:
           imageName: ghcr.io/rainforest-dev/nx
           cacheFrom: ghcr.io/rainforest-dev/nx
           push: always
-          platform: linux/amd64, linux/arm64

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -1,0 +1,28 @@
+name: pre-build dev container image
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Dev Container - NX
+        uses: devcontainers/cli@v0.3
+        with:
+          subFolder: common/nx
+          configFile: common/nx/devcontainer.json
+          imageName: ghcr.io/rainforest-dev/nx
+          cacheFrom: ghcr.io/rainforest-dev/nx
+          push: always
+          platform: linux/amd64, linux/arm64

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -6,8 +6,12 @@ on:
       - main
   workflow_dispatch:
 jobs:
-  build:
-    runs-on: ubuntu-24.04-arm
+  pre-build:
+    strategy:
+      matrix:
+        os: [macos-latest]
+        module: [nx, node]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -20,8 +24,8 @@ jobs:
       - name: Build Dev Container - NX
         uses: devcontainers/ci@v0.3
         with:
-          subFolder: common/nx
-          configFile: common/nx/devcontainer.json
-          imageName: ghcr.io/rainforest-dev/nx
-          cacheFrom: ghcr.io/rainforest-dev/nx
+          subFolder: common/${{ matrix.module }}
+          configFile: common/${{ matrix.module }}/devcontainer.json
+          imageName: ghcr.io/rainforest-dev/${{ matrix.module }}
+          cacheFrom: ghcr.io/rainforest-dev/${{ matrix.module }}
           push: always

--- a/.github/workflows/pre-build.yml
+++ b/.github/workflows/pre-build.yml
@@ -9,7 +9,7 @@ jobs:
   pre-build:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-24.04-arm]
         module: [nx, node]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # dev-containers
+
+```bash
+git clone https://github.com/rainforest-dev/rainforest-devcontainers.git github.com --single-branch
+```


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to pre-build development container images and updates the `README.md` file with instructions for cloning the repository.

New GitHub Actions workflow:

* [`.github/workflows/pre-build.yml`](diffhunk://#diff-2e537ee1e4e94d8ac47574797489e547f0b162b089ef5bc9b5d0718e8ba8c69bR1-R31): Added a new workflow to pre-build development container images for `nx` and `node` modules on `ubuntu-24.04-arm`. The workflow triggers on pull requests, pushes to the `main` branch, and manual dispatch. It includes steps for checking out the repository, logging into GitHub Container Registry, and building and pushing the dev container images.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R5): Added instructions for cloning the repository using a single branch.